### PR TITLE
Bump sktime to support python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,11 @@ repository = "https://github.com/philipdarke/torchtime"
 documentation = "https://philipdarke.com/torchtime"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.10"
+python = ">=3.8,<3.11"
 numpy = "^1.21.0"
 requests = "^2.27.1"
 scikit-learn = "^1.1.1"
-sktime = "^0.12.1"
+sktime = "^0.14"
 torch = "^1.11.0"
 tqdm = "^4.64.0"
 

--- a/tests/data_physionet2012_test.py
+++ b/tests/data_physionet2012_test.py
@@ -73,15 +73,15 @@ class TestPhysioNet2012:
         )
         assert (
             _get_SHA256(".torchtime/physionet_2012/X" + OBJ_EXT)
-            == "7cbd4b4a320facbe7a8c59664082902aab2fd2b8c2ff6cc09aaac1e0cb74f2f9"
+            == "0817ec770fc7be4e89e81c43070c1e82dc30da5d1d4ca795f41fe971f4289e2b"
         )
         assert (
             _get_SHA256(".torchtime/physionet_2012/y" + OBJ_EXT)
-            == "5b9bf1f58ff02e04397f68ae776fc519e20cae6e66a632b01fa309693c3de3e9"
+            == "cc6733d46d669eda55acbc89afcc8c7ee9a2563f6380ce6cf2ecd822adb37e4f"
         )
         assert (
             _get_SHA256(".torchtime/physionet_2012/length" + OBJ_EXT)
-            == "d4dbf3d19e9f03618f3113c57c5950031c22bad75c80744438e3121b1cff2204"
+            == "af748a55dd02e929564153a8a81fb7c12b26025aadfe2d2872e8bb51a9fe490b"
         )
 
     def test_train_val(self):

--- a/tests/data_physionet2019_test.py
+++ b/tests/data_physionet2019_test.py
@@ -73,15 +73,15 @@ class TestPhysioNet2019:
         )
         assert (
             _get_SHA256(".torchtime/physionet_2019/X" + OBJ_EXT)
-            == "ea94129dd03e594da80efae132b674b284499c613174d0314e13e8aaac179ba7"
+            == "6eb80cddc4eb4fe1c4cdcae8ad35becc75469737542ca66ac417fda90f3a1db3"
         )
         assert (
             _get_SHA256(".torchtime/physionet_2019/y" + OBJ_EXT)
-            == "5f3cf8f30e4bebf166c5a4f9d4c2030dfb82d57729e6b4e67409047150345c0e"
+            == "8fa4a9f7f8fc532aca0a9e0df6c6fe837c3ae3d070ceb28054259ff97c8241a5"
         )
         assert (
             _get_SHA256(".torchtime/physionet_2019/length" + OBJ_EXT)
-            == "209672aa41dc2f092a63e49accc4203598b2d4deb9b28b910cbbb4082518c618"
+            == "829c06fb86444f2ca806371583cd38fe2d0e29b9045ae6a4cad306bd4f4fad1f"
         )
 
     def test_train_val(self):

--- a/tests/data_physionet2019binary_test.py
+++ b/tests/data_physionet2019binary_test.py
@@ -73,15 +73,15 @@ class TestPhysioNet2019Binary:
         )
         assert (
             _get_SHA256(".torchtime/physionet_2019binary/X" + OBJ_EXT)
-            == "52b28760d1d2420b27d8003531ae42cdca14c6e408b024273c81a65d39c2f2df"
+            == "99dc8eb22eecb82f57ef301b63bac37f7656ce691d158f3e1e8db80205ce8ba1"
         )
         assert (
             _get_SHA256(".torchtime/physionet_2019binary/y" + OBJ_EXT)
-            == "dd78b55b728fe62798cadb28741d5cb0f243dfb3146aa6732baa26ecfe32ba40"
+            == "4d0c286a4c84ec9cffbb16babf7812365ee8b9220e7ea7fcfdb690b31ec26a87"
         )
         assert (
             _get_SHA256(".torchtime/physionet_2019binary/length" + OBJ_EXT)
-            == "d0c1c809d47485cb237e650d11264bcc9225f2c56d5754d4ebeda41cc87c63ba"
+            == "718660039c834375d1d547fe93788b50d4eb7e8a4323bbb5ee0fe531ba27f8bb"
         )
 
     def test_train_val(self):
@@ -344,15 +344,15 @@ class TestPhysioNet2019Binary:
         )
         assert (
             _get_SHA256(".torchtime/physionet_2019binary/X" + OBJ_EXT)
-            == "52b28760d1d2420b27d8003531ae42cdca14c6e408b024273c81a65d39c2f2df"
+            == "99dc8eb22eecb82f57ef301b63bac37f7656ce691d158f3e1e8db80205ce8ba1"
         )
         assert (
             _get_SHA256(".torchtime/physionet_2019binary/y" + OBJ_EXT)
-            == "dd78b55b728fe62798cadb28741d5cb0f243dfb3146aa6732baa26ecfe32ba40"
+            == "4d0c286a4c84ec9cffbb16babf7812365ee8b9220e7ea7fcfdb690b31ec26a87"
         )
         assert (
             _get_SHA256(".torchtime/physionet_2019binary/length" + OBJ_EXT)
-            == "d0c1c809d47485cb237e650d11264bcc9225f2c56d5754d4ebeda41cc87c63ba"
+            == "718660039c834375d1d547fe93788b50d4eb7e8a4323bbb5ee0fe531ba27f8bb"
         )
 
     def test_time(self):

--- a/tests/data_uea_arrowhead_test.py
+++ b/tests/data_uea_arrowhead_test.py
@@ -79,15 +79,15 @@ class TestUEAArrowHead:
         )
         assert (
             _get_SHA256(".torchtime/uea_" + DATASET + "/X" + OBJ_EXT)
-            == "9530efe27c6450c5da88a44c72ecd584b80c82599d62a3a02e0e09f572eb3a38"
+            == "8f2efb0e14fdd62da9ac10b6af22cd08b447f254aa51503a83616d628093cb35"
         )
         assert (
             _get_SHA256(".torchtime/uea_" + DATASET + "/y" + OBJ_EXT)
-            == "7f08d6239b17cad032fdc9a2d1f607b500825167a9884e2ad84f423a7513a30c"
+            == "aa1c0fd2f822b0ea722ab4495f91bc42a1a69eb82cdefb8095dbadbaf32a2182"
         )
         assert (
             _get_SHA256(".torchtime/uea_" + DATASET + "/length" + OBJ_EXT)
-            == "7348daeb7eb5239a1e400df18c574daabb03764e6c0422590c2ed44b014f9160"
+            == "a1c95d017898737daccad34efd06e25281797f04ed671a42a36b85269a7022e7"
         )
 
     def test_train_val(self):
@@ -384,15 +384,15 @@ class TestUEAArrowHead:
         )
         assert (
             _get_SHA256(".torchtime/uea_" + DATASET + "/X" + OBJ_EXT)
-            == "9530efe27c6450c5da88a44c72ecd584b80c82599d62a3a02e0e09f572eb3a38"
+            == "8f2efb0e14fdd62da9ac10b6af22cd08b447f254aa51503a83616d628093cb35"
         )
         assert (
             _get_SHA256(".torchtime/uea_" + DATASET + "/y" + OBJ_EXT)
-            == "7f08d6239b17cad032fdc9a2d1f607b500825167a9884e2ad84f423a7513a30c"
+            == "aa1c0fd2f822b0ea722ab4495f91bc42a1a69eb82cdefb8095dbadbaf32a2182"
         )
         assert (
             _get_SHA256(".torchtime/uea_" + DATASET + "/length" + OBJ_EXT)
-            == "7348daeb7eb5239a1e400df18c574daabb03764e6c0422590c2ed44b014f9160"
+            == "a1c95d017898737daccad34efd06e25281797f04ed671a42a36b85269a7022e7"
         )
 
     def test_time(self):

--- a/tests/data_uea_chartraj_test.py
+++ b/tests/data_uea_chartraj_test.py
@@ -79,15 +79,15 @@ class TestUEACharacterTrajectories:
         )
         assert (
             _get_SHA256(".torchtime/uea_" + DATASET + "/X" + OBJ_EXT)
-            == "977be55b8ed063e88991dc459c5d871136839f092dd8056dd408aa59db7dd27f"
+            == "1a472cca64a9b26997f54fb230bc9408a242b08dbb3df3080b0a52203e723b2c"
         )
         assert (
             _get_SHA256(".torchtime/uea_" + DATASET + "/y" + OBJ_EXT)
-            == "59b53905692701ec7e6c5ca2e8b61d06c44ec531a3d29c0bbb38ddec7754da80"
+            == "878a1aecdfc252cdd0bb3577616596f8a2c3b4e1f4b3e716cd8ddad304c7c8f6"
         )
         assert (
             _get_SHA256(".torchtime/uea_" + DATASET + "/length" + OBJ_EXT)
-            == "698d1ebefff52cff3c41da20feccbd141e856b16aa618b7e44c80daf54ab0e39"
+            == "2da6d9cf15a847c1f5a90d95c94f5d42221d9329ca565ebacd3334ef0db68916"
         )
 
     def test_train_val(self):
@@ -390,15 +390,15 @@ class TestUEACharacterTrajectories:
         )
         assert (
             _get_SHA256(".torchtime/uea_" + DATASET + "/X" + OBJ_EXT)
-            == "977be55b8ed063e88991dc459c5d871136839f092dd8056dd408aa59db7dd27f"
+            == "1a472cca64a9b26997f54fb230bc9408a242b08dbb3df3080b0a52203e723b2c"
         )
         assert (
             _get_SHA256(".torchtime/uea_" + DATASET + "/y" + OBJ_EXT)
-            == "59b53905692701ec7e6c5ca2e8b61d06c44ec531a3d29c0bbb38ddec7754da80"
+            == "878a1aecdfc252cdd0bb3577616596f8a2c3b4e1f4b3e716cd8ddad304c7c8f6"
         )
         assert (
             _get_SHA256(".torchtime/uea_" + DATASET + "/length" + OBJ_EXT)
-            == "698d1ebefff52cff3c41da20feccbd141e856b16aa618b7e44c80daf54ab0e39"
+            == "2da6d9cf15a847c1f5a90d95c94f5d42221d9329ca565ebacd3334ef0db68916"
         )
 
     def test_time(self):

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -19,8 +19,8 @@ class TestUtils:
         """Fixture for checksum tests."""
         generator = torch.Generator().manual_seed(SEED)
         X = torch.rand((N, S, C), generator=generator)
-        sha = "60dd512baf28adcfe07484ee6d893d4c9f927cdd9865538a75d9664eb1ff9cde"
-        sha_error = "60dd512baf28adcfe07484ee6d893d4c9f927cdd9865538a75d9664eb1ff9pad"
+        sha = "3460c01e7ab9d6bfab46c1802e52362f997bf03c1723c7cf7fc70cd5df0de780"
+        sha_error = "3460c01e7ab9d6bfab46c1802e52362f997bf03c1723c7cf7fc70cd5df0de780pad"
         X_path = ".torchtime/X.pt"
         sha_path = ".torchtime/correct.sha256"
         error_path = ".torchtime/error.sha256"


### PR DESCRIPTION
Hey, now that sktime has wheels available for 3.10, I thought it would be a good idea to upgrade the Python version to 3.10. At least locally, your tests are passing. Could you take a look @philipdarke?